### PR TITLE
fix(password): Update the flag comparison

### DIFF
--- a/password/password.go
+++ b/password/password.go
@@ -1,24 +1,25 @@
 package password
 
-// Flag password material requirement
+// Flag denotes the expected or actual element of the password.
 type Flag uint8
 
 const (
-	// N Numbers
+	// N denotes the numerals.
 	N Flag = 1 << 0
-	// L_OR_U Uppercase or lowercase letter
+	// L_OR_U denotes the lowercase or uppercase letters.
 	L_OR_U Flag = 1 << 1
-	// L Lowercase letters
+	// L denotes the lowercase letters.
 	L Flag = 1 << 2
-	// U Uppercase letter
+	// U denotes the uppercase letters.
 	U Flag = 1 << 3
-	// S Symbols found on the keyboard (all keyboard characters not defined as letters or numerals) and spaces
+	// S denotes the printable symbols found on the keyboard, except letters, numerals and spaces.
 	S Flag = 1 << 4
 
+	// mask is used for extracting the 5 least significant bits of the flag.
 	mask Flag = 0x1f
 )
 
-// CheckPassword checks if the password matches the format requirements.
+// CheckPassword checks if the actual element of the password matches the expected flag.
 func CheckPassword(pw string, flag Flag, minLen int, maxLen ...int) bool {
 	if len(pw) < minLen ||
 		(len(maxLen) > 0 && len(pw) > maxLen[0]) {
@@ -47,5 +48,6 @@ func CheckPassword(pw string, flag Flag, minLen int, maxLen ...int) bool {
 			return false
 		}
 	}
+	r &^= flag & (L|U) ^ (L|U)
 	return r == flag
 }

--- a/password/password_test.go
+++ b/password/password_test.go
@@ -3,17 +3,19 @@ package password
 import "fmt"
 
 func ExampleCheckPassword() {
-	fmt.Println(CheckPassword("A", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("a", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("1", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("Aa", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("A1", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("a1", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("Aa1", N|L_OR_U, 6))
-	fmt.Println(CheckPassword("Aa12345", N|L_OR_U, 6))
+	fmt.Println(CheckPassword("A", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("a", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("1", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("Aa", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("A1", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("a1", N|L_OR_U, 2))
+	fmt.Println(CheckPassword("Aa1", N|L_OR_U, 2))
 	fmt.Println(CheckPassword("AaBbCcDd", L|U, 6))
 	fmt.Println(CheckPassword("ABCD1234", N|U, 6))
+	fmt.Println(CheckPassword("ABCD1234", N|L_OR_U|U, 6))
+	fmt.Println(CheckPassword("ABCD1234", N|L_OR_U|L, 6))
 	fmt.Println(CheckPassword("abcd1234", N|L, 6, 7))
+	fmt.Println(CheckPassword("Aa123456", N|L_OR_U, 6, 8))
 	fmt.Println(CheckPassword("Aa@123456", Flag(1<<6)|N|L|U|S, 6, 16))
 	fmt.Println(CheckPassword("Aa123456语言", N|L|U, 6))
 	// Output:
@@ -21,13 +23,15 @@ func ExampleCheckPassword() {
 	// false
 	// false
 	// false
-	// false
-	// false
-	// false
-	// false
+	// true
+	// true
+	// true
+	// true
 	// true
 	// true
 	// false
+	// false
+	// true
 	// true
 	// false
 }


### PR DESCRIPTION
The example `CheckPassword("Aa12345", N|L_OR_U, 6)` returned `false` before, but it returns `true` with the latest flag comparison logic.

The details of update is shown as following:

1. Update the comments in password/password.go
2. Update the test examples in password/password_test.go
3. Update the flag comparison logic:
  - `L_OR_U`: It should include either the lowercase or the uppercase letter.
  - `L_OR_U|L`: It must include the lowercase letter, while the uppercase letter is optional.
  - `L_OR_U|U`: It must include the uppercase letter, while the lowercase letter is optional.
  - `L_OR_U|L|U`: It must include both the lowercase and the uppercase letter, which is equal to `L|U`.
