### PR TITLE
fix httpbody/NewFormBody.go

### DIFF
--- a/httpbody/httpbody.go
+++ b/httpbody/httpbody.go
@@ -33,7 +33,7 @@ func NewFormBody(values, files url.Values) (contentType string, bodyReader io.Re
 	if len(files) == 0 {
 		return "application/x-www-form-urlencoded", strings.NewReader(values.Encode()), nil
 	}
-	var rw = bytes.NewBuffer(make([]byte, 32*1024*len(files)))
+	var rw = bytes.NewBuffer(make([]byte, 0, 32*1024*len(files)))
 	var bodyWriter = multipart.NewWriter(rw)
 	var buf = make([]byte, 32*1024)
 	var fileWriter io.Writer


### PR DESCRIPTION
原函数申请bytebuffer后，预分配空间不为0，导致写入body数据后前面填充了不可识别的'\0'字符。
现修正预分配空间为0